### PR TITLE
docs: fix contributor heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Your contributions are what make the community great. We encourage you to be a part of it. Here are some important notes for contributors:
 
-#### Preperaing Changes
+#### Preparing Changes
 
 **We use `changesets` to manage versioning and changelog generation.**
 


### PR DESCRIPTION
Fix the typo in the contributor guide heading from Preperaing Changes to Preparing Changes.

Validation:
- git diff --check passed.