### PR TITLE
fix(relay-kit): restrict URL signing to authorized MoonPay hosts in sign-url endpoint

### DIFF
--- a/demo/pages/api/sign-url.ts
+++ b/demo/pages/api/sign-url.ts
@@ -5,24 +5,50 @@ type ResponseData = {
   signature: null | string
 }
 
+const MOONPAY_HOSTS = new Set(['buy.moonpay.com', 'buy-sandbox.moonpay.com'])
+
+function isAllowedMoonPayUrl(url: URL): boolean {
+  return url.protocol === 'https:' && MOONPAY_HOSTS.has(url.hostname)
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ResponseData>
 ) {
   const { url: _url, ...query } = req.query
 
-  const url = new URL(_url as string)
-
-  for (const [key, value] of Object.entries(query)) {
-    url.searchParams.set(key, value as string)
-  }
-
-  if (!url) {
+  if (typeof _url !== 'string') {
     res.status(400).json({ signature: null })
     return
   }
+
+  let url: URL
+  try {
+    url = new URL(_url)
+  } catch {
+    res.status(400).json({ signature: null })
+    return
+  }
+
+  if (!isAllowedMoonPayUrl(url)) {
+    res.status(400).json({ signature: null })
+    return
+  }
+
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === 'string') {
+      url.searchParams.set(key, value)
+    }
+  }
+
+  const moonPaySecret = process.env.NEXT_MOONPAY_SECRET
+  if (!moonPaySecret) {
+    res.status(500).json({ signature: null })
+    return
+  }
+
   const signature = crypto
-    .createHmac('sha256', process.env.NEXT_MOONPAY_SECRET!)
+    .createHmac('sha256', moonPaySecret)
     .update(url.search)
     .digest('base64')
 


### PR DESCRIPTION
## Motivation

This PR hardens the `sign-url` API endpoint in the `relay-kit` demo to prevent arbitrary URL signing. Previously, the endpoint lacked strict domain validation before generating HMAC SHA-256 signatures using the server-side MoonPay secret. This allowed potential abuse where the backend could be tricked into signing unauthorized or malicious URLs. By introducing an explicit allowlist, we ensure the server only signs legitimate MoonPay production and sandbox endpoints.

## Modifications

* **Domain Allowlist & Protocol Validation (`demo/pages/api/sign-url.ts`)**:
  * Introduced a strict `MOONPAY_HOSTS` Set containing `buy.moonpay.com` and `buy-sandbox.moonpay.com`.
  * Added the `isAllowedMoonPayUrl` helper to verify that incoming URLs strictly use the `https:` protocol and match the authorized hostnames.
* **Enhanced Error Handling (`demo/pages/api/sign-url.ts`)**:
  * Added robust `try-catch` URL parsing and early-exit HTTP `400 Bad Request` responses for malformed, non-string, or unauthorized URLs before any cryptographic operations are performed.

## Checklist

- [x] Format your code according to the Contributor Guide.
- [ ] Add unit tests as outlined in the Contributor Guide.
- [x] Update documentation as needed, including docstrings or example tutorials.