### PR TITLE
Fix Tron swap UX in the TRX/USDT flow

### DIFF
--- a/.changeset/tron-swap-ux.md
+++ b/.changeset/tron-swap-ux.md
@@ -1,0 +1,20 @@
+---
+'@relayprotocol/relay-sdk': patch
+'@relayprotocol/relay-kit-ui': patch
+'@relayprotocol/relay-tron-wallet-adapter': patch
+---
+
+Fix Tron swap UX in the TRX/USDT flow. Tron balances now read from TronGrid's
+fullnode endpoints (`wallet/getaccount`, `wallet/triggerconstantcontract`)
+instead of the solidity node, so they reflect a completed swap without waiting
+roughly a minute for solidification or needing a manual refresh.
+`adaptTronWallet` confirms transactions with `getUnconfirmedTransactionInfo`,
+which returns the receipt seconds after inclusion, so a successful approval no
+longer hangs or reports a false "Transaction confirmation timed out".
+
+Same-chain swaps that the solver has to fill — Tron TRX/USDT, deposit-address
+routes, and forced solver execution — now show the cross-chain pending states
+and wait for the fill to be confirmed before reporting success. Previously any
+route whose origin and destination chain ids matched was assumed to settle with
+the user's own transaction. The new `isSolverFilledStep` export identifies these
+routes from the step the API returns.

--- a/packages/relay-tron-wallet-adapter/src/adapter.ts
+++ b/packages/relay-tron-wallet-adapter/src/adapter.ts
@@ -72,7 +72,7 @@ export const adaptTronWallet = (
     },
     handleConfirmTransactionStep: async (txId) => {
       const pollMs = 1500
-      const timeoutMs = 60_000
+      const timeoutMs = 90_000
       const targetConfs = 1
 
       const start = Date.now()
@@ -81,9 +81,10 @@ export const adaptTronWallet = (
         0
 
       while (true) {
-        // 1) Ask for the execution receipt (appears once included in a block)
+        // 1) Ask for the execution receipt (appears once included in a block).
+        // Fullnode variant: the solidity node only serves it after solidification (~57s).
         const info = await tronWeb.trx
-          .getTransactionInfo(txId)
+          .getUnconfirmedTransactionInfo(txId)
           .catch(() => undefined)
 
         if (info && typeof info.blockNumber === 'number') {

--- a/packages/sdk/src/utils/executeSteps/executeSteps.test.ts
+++ b/packages/sdk/src/utils/executeSteps/executeSteps.test.ts
@@ -20,6 +20,7 @@ import { postSignatureExtraSteps } from '../../../tests/data/postSignatureExtraS
 import { swapWithApproval } from '../../../tests/data/swapWithApproval'
 import { swapWithZeroResetApproval } from '../../../tests/data/swapWithZeroResetApproval'
 import { adaptViemWallet } from '../viemWallet'
+import { sameChainDeposit } from '../../../tests/data/sameChainDeposit'
 
 const viemChains = [mainnet, base, zora, optimism, arbitrum, arbitrumNova]
 const relayChains = viemChains.map(convertViemChainToRelayChain)
@@ -1754,5 +1755,99 @@ describe('Should test WebSocket functionality', () => {
         })
       )
     })
+  })
+})
+
+describe('Same-chain step completion.', () => {
+  let statusSpy: ReturnType<typeof vi.spyOn>
+
+  const mockStatusSequence = (statuses: string[]) => {
+    let index = 0
+    statusSpy = vi.spyOn(axios, 'request').mockImplementation((config: any) => {
+      if (config.url?.includes('/intents/status')) {
+        const status = statuses[Math.min(index, statuses.length - 1)]
+        index++
+        return Promise.resolve({
+          data: { status, txHashes: ['0x'] },
+          status: 200
+        }) as any
+      }
+      return Promise.resolve({
+        data: { status: 'success' },
+        status: 200
+      }) as any
+    })
+    return statusSpy
+  }
+
+  const statusCallCount = () =>
+    statusSpy.mock.calls.filter((call: any) =>
+      call[0]?.url?.includes('/intents/status')
+    ).length
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetAllMocks()
+    axiosPostSpy = mockAxiosPost()
+    wallet = {
+      vmType: 'evm',
+      getChainId: () => Promise.resolve(1),
+      transport: http(mainnet.rpcUrls.default.http[0]),
+      address: () => Promise.resolve('0x'),
+      handleSignMessageStep: vi.fn().mockResolvedValue('0x'),
+      handleSendTransactionStep: vi.fn().mockResolvedValue('0x'),
+      handleConfirmTransactionStep: vi.fn().mockResolvedValue('0x'),
+      switchChain: vi.fn().mockResolvedValue('0x'),
+      supportsAtomicBatch: vi.fn().mockResolvedValue(false),
+      handleBatchTransactionStep: vi.fn().mockResolvedValue('0x')
+    }
+    client = createClient({
+      baseApiUrl: MAINNET_RELAY_API,
+      chains: relayChains,
+      pollingInterval: 10
+    })
+  })
+
+  it('Should complete an atomic same-chain swap without waiting for a solver fill.', async () => {
+    mockStatusSequence(['pending', 'pending', 'success'])
+
+    await executeSteps(
+      1,
+      {},
+      wallet,
+      () => {},
+      JSON.parse(JSON.stringify(swapWithApproval)) as Execute,
+      undefined
+    )
+
+    // The origin receipt settles the swap, so the fill status is never awaited.
+    expect(statusCallCount()).toBeLessThanOrEqual(1)
+  })
+
+  it('Should wait for the solver fill on a same-chain deposit step.', async () => {
+    mockStatusSequence(['pending', 'pending', 'success'])
+
+    await executeSteps(
+      1,
+      {},
+      wallet,
+      () => {},
+      JSON.parse(JSON.stringify(sameChainDeposit)) as Execute,
+      undefined
+    )
+
+    expect(statusCallCount()).toBeGreaterThanOrEqual(3)
+  })
+
+  it('Should complete an atomic same-chain send without waiting for a solver fill.', async () => {
+    mockStatusSequence(['pending', 'pending', 'success'])
+
+    const quote = JSON.parse(JSON.stringify(sameChainDeposit)) as Execute
+    quote.steps[0].id = 'send'
+
+    await executeSteps(1, {}, wallet, () => {}, quote, undefined)
+
+    expect(statusCallCount()).toBeLessThanOrEqual(1)
+    expect(quote.steps[0].items?.[0].status).toBe('complete')
   })
 })

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -12,6 +12,7 @@ export {
 } from './viemWallet.js'
 export { convertViemChainToRelayChain, type RelayAPIChain } from './chain.js'
 export { getCurrentStepData } from './getCurrentStepData.js'
+export { isSolverFilledStep } from './solverFill.js'
 export {
   type SimulateContractRequest,
   isSimulateContractRequest

--- a/packages/sdk/src/utils/solverFill.test.ts
+++ b/packages/sdk/src/utils/solverFill.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { isSolverFilledStep } from './solverFill'
+import type { Execute } from '../types'
+
+const step = (id: string) => ({ id }) as Execute['steps'][0]
+
+describe('isSolverFilledStep', () => {
+  it('Should treat deposit steps as solver filled.', () => {
+    expect(isSolverFilledStep(step('deposit'))).toBe(true)
+  })
+
+  it('Should treat every other transaction step as atomic.', () => {
+    for (const id of ['swap', 'send', 'approve', 'approval']) {
+      expect(isSolverFilledStep(step(id))).toBe(false)
+    }
+  })
+})

--- a/packages/sdk/src/utils/solverFill.ts
+++ b/packages/sdk/src/utils/solverFill.ts
@@ -1,0 +1,17 @@
+import type { Execute } from '../types/index.js'
+
+/**
+ * True when the step is filled by the solver rather than settled atomically by
+ * the user's own transaction.
+ *
+ * The API emits `deposit` whenever the request is routed as an intent — every
+ * cross-chain route, deposit-address routes, forced solver execution, and
+ * same-chain routes with no on-chain aggregator to swap through (Tron). Origin
+ * and destination chain ids are not a reliable signal: those same-chain intents
+ * report matching ids while still requiring a separate fill.
+ *
+ * Atomic steps (`swap`, `send`) complete with the origin transaction and must
+ * not be made to wait on the status API.
+ */
+export const isSolverFilledStep = (step: Execute['steps'][0]): boolean =>
+  step.id === 'deposit'

--- a/packages/sdk/src/utils/transaction.ts
+++ b/packages/sdk/src/utils/transaction.ts
@@ -17,6 +17,7 @@ import type {
   AxiosResponse
 } from 'axios'
 import { getClient } from '../client.js'
+import { isSolverFilledStep } from './solverFill.js'
 import {
   DepositTransactionTimeoutError,
   SolverStatusTimeoutError,
@@ -524,10 +525,14 @@ export async function sendTransactionSafely(
     const confirmationPromise = pollForConfirmation(receiptController)
 
     await Promise.race([receiptPromise, confirmationPromise])
-    const isSameChain = details?.currencyOut?.currency?.chainId === chainId
+    // Same-chain intents (deposit) still need a solver fill, so only atomic
+    // same-chain steps are complete once the origin receipt lands.
+    const isSameChainAtomic =
+      details?.currencyOut?.currency?.chainId === chainId &&
+      !isSolverFilledStep(step)
 
     if (waitingForConfirmation) {
-      if (!isSameChain) {
+      if (!isSameChainAtomic) {
         await confirmationPromise
       } else {
         waitingForConfirmation = false

--- a/packages/sdk/tests/data/sameChainDeposit.ts
+++ b/packages/sdk/tests/data/sameChainDeposit.ts
@@ -1,0 +1,63 @@
+import type { Execute } from '../../src/types'
+
+/**
+ * Same-chain swap routed as an intent: matching chain ids, but a `deposit` step
+ * the solver has to fill. Produced by deposit-address routes, forced solver
+ * execution, and chains with no on-chain aggregator (Tron).
+ */
+export const sameChainDeposit: Execute = {
+  steps: [
+    {
+      id: 'deposit',
+      action: 'Confirm transaction in your wallet',
+      description: 'Depositing funds to the relayer to execute the swap',
+      kind: 'transaction',
+      requestId: '0xabc',
+      items: [
+        {
+          status: 'incomplete',
+          data: {
+            to: '0x00000000bb6dd3b0032d930f72cac8e56166d93c',
+            data: '0x01020304',
+            value: '1000000000000000',
+            chainId: 1
+          },
+          check: {
+            endpoint: '/intents/status?requestId=0xabc',
+            method: 'GET'
+          }
+        }
+      ]
+    }
+  ],
+  fees: {},
+  details: {
+    operation: 'swap',
+    sender: '0x03508bB71268BBA25ECaCC8F620e01866650532c',
+    recipient: '0x03508bB71268BBA25ECaCC8F620e01866650532c',
+    currencyIn: {
+      currency: {
+        chainId: 1,
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18
+      },
+      amount: '1000000000000000',
+      amountFormatted: '0.001',
+      amountUsd: '3.417570'
+    },
+    currencyOut: {
+      currency: {
+        chainId: 1,
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        symbol: 'USDC',
+        name: 'USDCoin',
+        decimals: 6
+      },
+      amount: '3410000',
+      amountFormatted: '3.41',
+      amountUsd: '3.410000'
+    }
+  }
+}

--- a/packages/ui/src/hooks/useTronBalance.ts
+++ b/packages/ui/src/hooks/useTronBalance.ts
@@ -147,7 +147,7 @@ export default (
     queryFn: async () => {
       if (address) {
         if (currency === trxAddress || !currency) {
-          const response = await fetch(`${rpcUrl}/walletsolidity/getaccount`, {
+          const response = await fetch(`${rpcUrl}/wallet/getaccount`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'
@@ -173,20 +173,17 @@ export default (
           const owner20 = await tronBase58ToHex20Async(address)
           const parameter = pad32(owner20.slice(2))
 
-          const res = await fetch(
-            `${rpcUrl}/walletsolidity/triggerconstantcontract`,
-            {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({
-                owner_address: address,
-                contract_address: currency,
-                function_selector: 'balanceOf(address)',
-                parameter,
-                visible: true
-              })
-            }
-          )
+          const res = await fetch(`${rpcUrl}/wallet/triggerconstantcontract`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              owner_address: address,
+              contract_address: currency,
+              function_selector: 'balanceOf(address)',
+              parameter,
+              visible: true
+            })
+          })
           const data = await res.json()
 
           if (data.error) {

--- a/packages/ui/src/utils/steps.ts
+++ b/packages/ui/src/utils/steps.ts
@@ -1,4 +1,5 @@
 import type { Execute, RelayChain } from '@relayprotocol/relay-sdk'
+import { isSolverFilledStep } from '@relayprotocol/relay-sdk'
 import type { Token, LinkedWallet } from '../types/index.js'
 import { NormalizedWalletName } from '../constants/walletCompatibility.js'
 
@@ -187,8 +188,10 @@ export const formatTransactionSteps = ({
     (step) => step.id === 'approve' || (step.id as any) === 'approval'
   )
 
-  // Determine transaction type
-  const isSameChain = fromChain?.id === toChain?.id
+  // Determine transaction type. Same-chain intents (deposit) are filled by the
+  // solver, so they take the cross-chain sequence despite matching chain ids.
+  const isSameChainId = fromChain?.id === toChain?.id
+  const usesSolverFill = executableSteps.some(isSolverFilledStep)
 
   // Find current active step and its state
   const currentActiveStep = executableSteps.find((step) =>
@@ -211,8 +214,10 @@ export const formatTransactionSteps = ({
     toChain?.id ||
     quote?.details?.currencyOut?.currency?.chainId
 
+  // Keyed on chain ids, not the step sequence: when they match, an origin hash
+  // is indistinguishable from a destination one.
   const hasDestinationTxHashes =
-    !isSameChain &&
+    !isSameChainId &&
     !!destinationChainId &&
     executableSteps.some((step) =>
       step.items?.some(
@@ -445,7 +450,7 @@ export const formatTransactionSteps = ({
   }
 
   // Create fixed step sequence based on transaction type
-  if (isSameChain) {
+  if (isSameChainId && !usesSolverFill) {
     // Same-chain: 1-2 steps (approval + swap, or just swap)
     if (hasApproval) {
       // Step 1: Approval


### PR DESCRIPTION
Read Tron balances from TronGrid's fullnode endpoints instead of the solidity node, and confirm Tron transactions with getUnconfirmedTransactionInfo, so balances and approvals no longer wait on solidification.

Gate the same-chain completion shortcut on the step being atomic. Tron TRX/USDT, deposit-address routes and forced solver execution all report matching origin and destination chain ids while still requiring a solver fill, so keying on chain ids alone reported success before the fill landed and rendered the same-chain step sequence for them.